### PR TITLE
Fix tests for rails 5.2 upgrade

### DIFF
--- a/lib/acts_as_taggable_on/taggable/dirty.rb
+++ b/lib/acts_as_taggable_on/taggable/dirty.rb
@@ -27,6 +27,11 @@ module ActsAsTaggableOn::Taggable
             def #{tag_type}_list_changes
               [changed_attributes['#{tag_type}_list'], __send__('#{tag_type}_list')] if changed_attributes.include?("#{tag_type}_list")
             end
+
+            private
+            def attribute_change(attr)
+              [changed_attributes[attr], __send__(attr)] if attribute_changed?(attr)
+            end
           RUBY
 
         end


### PR DESCRIPTION
This allows all the tests to pass.

This little override causes the "attribute query" to go via `ActsAsTaggableOn::Taggable::Core#tag_list` which for whatever reason, returns the expected result for the new `tag_list` value (`["one"]` instead of `nil`).

I'll admit, I am far from having my head around this library as well as rails Active Model/Record, so this may not be the best "fix".